### PR TITLE
Fix for Turbolinks

### DIFF
--- a/simple-slideout-menu.js
+++ b/simple-slideout-menu.js
@@ -23,6 +23,8 @@
     };
 
   $(document)
+    .on('touchend.menu.open', '[data-toggle="menu"]', showMenu)
+    .on('touchend.menu.close', '[data-dismiss="menu"]', hideMenu)
     .on('click.menu.open', '[data-toggle="menu"]', showMenu)
     .on('click.menu.close', '[data-dismiss="menu"]', hideMenu)
     .on('menu.close', hideMenu)

--- a/simple-slideout-menu.js
+++ b/simple-slideout-menu.js
@@ -26,6 +26,7 @@
     .on('click.menu.open', '[data-toggle="menu"]', showMenu)
     .on('click.menu.close', '[data-dismiss="menu"]', hideMenu)
     .on('menu.close', hideMenu)
-    .on('menu.open', showMenu);
+    .on('menu.open', showMenu)
+    .on('page:change', hideMenu);
 
 }(jQuery);


### PR DESCRIPTION
Libraries such as Turbolinks (Rails) dynamically override links preventing a full page refresh in order to more efficiently use the wire transparently.

However, as a result, a link clicked from an open menu refreshes the page but does not reset the `shown` variable to `false`. By observing the `page:change` event calling `hideMenu` we reset the state to the assumed default.
