### PR TITLE
add additional hooks for Turbolinks and jQuery updates

### DIFF
--- a/simple-slideout-menu.js
+++ b/simple-slideout-menu.js
@@ -23,9 +23,12 @@
     };
 
   $(document)
+    .on('touchend.menu.open', '[data-toggle="menu"]', showMenu)
+    .on('touchend.menu.close', '[data-dismiss="menu"]', hideMenu)
     .on('click.menu.open', '[data-toggle="menu"]', showMenu)
     .on('click.menu.close', '[data-dismiss="menu"]', hideMenu)
     .on('menu.close', hideMenu)
-    .on('menu.open', showMenu);
+    .on('menu.open', showMenu)
+    .on('page:change', hideMenu);
 
 }(jQuery);


### PR DESCRIPTION
I deleted and recreated my PR this time, so here is a less elegant explanation.
1. I believe when you wrote this 'touchend' events were combined with 'click' events, which is no longer true. So the hook wasn't getting attached with the version of jQuery I'm using now meaning that clicking buttons on mobile did not / did not trigger the menu
2. The additional hook of `page:change` I've added for frameworks like Rails (sigh?) which use Turbolinks, which over-rides links to reduce activity on the wire. It means that `ready` events won't fire, and the `shown` variable doesn't get reset back to `false` since the page never actually fully reloads. So subsequent clicks of a hamburger icon for instance will not work since the menu won't expand because the logic believes it is already expanded.
